### PR TITLE
feat(update): add --max-versions option

### DIFF
--- a/src/ops2deb/cli.py
+++ b/src/ops2deb/cli.py
@@ -230,11 +230,21 @@ def update(
         help="Name of blueprint that should not be updated. Can be used multiple times.",
     ),
     only: Optional[List[str]] = option_only,
+    max_versions: int = typer.Option(
+        1, "-m", "--max-versions", envvar="OPS2DEB_MAX_VERSIONS"
+    ),
 ) -> None:
     try:
         fetcher = Fetcher(cache_directory, lockfile_path)
         updater.update(
-            configuration_path, lockfile_path, fetcher, dry_run, output_path, skip, only
+            configuration_path,
+            lockfile_path,
+            fetcher,
+            dry_run,
+            output_path,
+            skip,
+            only,
+            max_versions,
         )
     except Ops2debError as e:
         error(e, exit_code)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,9 @@ def mock_lockfile(lockfile_path) -> None:
     - url: http://testserver/1.0.0/great-app.tar.gz
       sha256: f1be6dd36b503641d633765655e81cdae1ff8f7f73a2582b7468adceb5e212a9
       timestamp: 2022-12-29 13:14:57+00:00
+    - url: http://testserver/1.1.0/great-app.tar.gz
+      sha256: f1be6dd36b503641d633765655e81cdae1ff8f7f73a2582b7468adceb5e212a9
+      timestamp: 2022-12-29 13:14:57+00:00
     - url: http://testserver/1.0.0/not-found.zip
       sha256: 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
       timestamp: 2022-12-29 13:14:57+00:00

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -46,6 +46,22 @@ def test_render_fetch_url_should_evaluate_goarch_and_rust_targets_and_target(
     assert blueprint.render_fetch_url() == "http://amd64/x86_64-unknown-linux-gnu/x86_64"
 
 
+def test_render_fetch_urls_should_return_one_url_per_arch_per_version():
+    blueprint = Blueprint(
+        name="great-app",
+        summary="summary",
+        matrix=dict(architectures=["amd64", "armhf"], versions=["1.0.0", "1.1.1"]),
+        fetch="http://{{version}}/{{goarch}}/app.tar.gz",
+    )
+    urls = [
+        "http://1.0.0/amd64/app.tar.gz",
+        "http://1.1.1/amd64/app.tar.gz",
+        "http://1.0.0/arm/app.tar.gz",
+        "http://1.1.1/arm/app.tar.gz",
+    ]
+    assert blueprint.render_fetch_urls() == urls
+
+
 def test_blueprint_should_evaluate_env_jinja_function_when_used_in_string_attributes(
     blueprint_factory,
 ):


### PR DESCRIPTION
This option lets you set the maximum number of blueprint versions ops2deb will keep when running ops2deb update.