### PR TITLE
feat: add tmp jinja variable

### DIFF
--- a/src/ops2deb/cli.py
+++ b/src/ops2deb/cli.py
@@ -11,7 +11,7 @@ from typer.core import TyperGroup
 from ops2deb import __version__, builder, formatter, generator, logger, updater
 from ops2deb.exceptions import Ops2debError
 from ops2deb.fetcher import DEFAULT_CACHE_DIRECTORY, Fetcher
-from ops2deb.parser import ConfigurationFile
+from ops2deb.parser import Configuration
 
 
 class DefaultCommandGroup(TyperGroup):
@@ -148,7 +148,7 @@ def default(
     workers_count: int = option_workers_count,
 ) -> None:
     try:
-        configuration = ConfigurationFile(configuration_path)
+        configuration = Configuration(configuration_path)
         fetcher = Fetcher(cache_directory, configuration.lockfile_path or lockfile_path)
         packages = generator.generate(
             fetcher,
@@ -175,7 +175,7 @@ def generate(
     only: Optional[List[str]] = option_only,
 ) -> None:
     try:
-        configuration = ConfigurationFile(configuration_path)
+        configuration = Configuration(configuration_path)
         fetcher = Fetcher(cache_directory, configuration.lockfile_path or lockfile_path)
         generator.generate(
             fetcher,
@@ -236,7 +236,7 @@ def update(
     ),
 ) -> None:
     try:
-        configuration = ConfigurationFile(configuration_path)
+        configuration = Configuration(configuration_path)
         fetcher = Fetcher(cache_directory, configuration.lockfile_path or lockfile_path)
         updater.update(
             configuration,
@@ -258,7 +258,7 @@ def validate(
     configuration_path: Path = option_configuration,
 ) -> None:
     try:
-        ConfigurationFile(configuration_path)
+        Configuration(configuration_path)
     except Ops2debError as e:
         error(e, exit_code)
 
@@ -289,7 +289,7 @@ def lock(
     cache_directory: Path = option_cache_directory,
 ) -> None:
     try:
-        configuration = ConfigurationFile(configuration_path)
+        configuration = Configuration(configuration_path)
         fetcher = Fetcher(cache_directory, configuration.lockfile_path or lockfile_path)
         fetcher.update_lockfile(configuration_path)
     except Ops2debError as e:

--- a/src/ops2deb/fetcher.py
+++ b/src/ops2deb/fetcher.py
@@ -16,7 +16,7 @@ from ops2deb import logger
 from ops2deb.client import client_factory
 from ops2deb.exceptions import Ops2debError, Ops2debExtractError, Ops2debFetcherError
 from ops2deb.lockfile import Lock
-from ops2deb.parser import ConfigurationFile
+from ops2deb.parser import Configuration
 from ops2deb.utils import log_and_raise, separate_results_from_errors
 
 DEFAULT_CACHE_DIRECTORY = Path("/tmp/ops2deb_cache")
@@ -196,7 +196,7 @@ class Fetcher:
 
     def update_lockfile(self, configuration_path: Path) -> None:
         urls: list[str] = []
-        for blueprint in ConfigurationFile(configuration_path).blueprints:
+        for blueprint in Configuration(configuration_path).blueprints:
             urls += blueprint.render_fetch_urls()
         results, fetch_errors = asyncio.run(self.fetch_urls(urls))
         self.lock.add(list(results.values()))

--- a/src/ops2deb/formatter.py
+++ b/src/ops2deb/formatter.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Optional, OrderedDict, Tuple
 import yaml
 
 from ops2deb.exceptions import Ops2debFormatterError
-from ops2deb.parser import Blueprint, ConfigurationFile
+from ops2deb.parser import Blueprint, Configuration
 from ops2deb.utils import PrettyYAMLDumper
 
 
@@ -50,7 +50,7 @@ def format(
     configuration_path: Path,
     additional_blueprint_formatting: Optional[Callable[[dict[str, Any]], None]] = None,
 ) -> None:
-    configuration = ConfigurationFile(configuration_path)
+    configuration = Configuration(configuration_path)
 
     # sort blueprints by name, version and revision
     raw_blueprints = sort_blueprints(configuration.aslist())

--- a/src/ops2deb/parser.py
+++ b/src/ops2deb/parser.py
@@ -207,11 +207,11 @@ class Blueprint(Base):
         return self._index
 
 
-class Configuration(Base):
+class _ConfigurationFile(Base):
     __root__: list[Blueprint] | Blueprint
 
 
-class ConfigurationFile:
+class Configuration:
     def __init__(self, configuration_path: Path, yaml: YAML | None = None) -> None:
         self.yaml: YAML = yaml or YAML()
         self.yaml.Emitter = FixIndentEmitter
@@ -242,7 +242,7 @@ class ConfigurationFile:
 
     def _validate(self) -> list[Blueprint]:
         try:
-            blueprints = Configuration.parse_obj(self._dict).__root__
+            blueprints = _ConfigurationFile.parse_obj(self._dict).__root__
         except ValidationError as e:
             raise Ops2debParserError(f"Invalid configuration file.\n{e}")
         if isinstance(blueprints, Blueprint):

--- a/src/ops2deb/updater.py
+++ b/src/ops2deb/updater.py
@@ -15,7 +15,7 @@ from ops2deb.client import client_factory
 from ops2deb.exceptions import Ops2debError, Ops2debUpdaterError
 from ops2deb.fetcher import Fetcher, FetchResult
 from ops2deb.lockfile import Lock
-from ops2deb.parser import Blueprint, ConfigurationFile
+from ops2deb.parser import Blueprint, Configuration
 from ops2deb.utils import separate_results_from_errors
 
 
@@ -296,7 +296,7 @@ def _update_lockfile(
 
 
 def update(
-    configuration: ConfigurationFile,
+    configuration: Configuration,
     fetcher: Fetcher,
     dry_run: bool = False,
     output_path: Path | None = None,

--- a/tests/test_ops2deb.py
+++ b/tests/test_ops2deb.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 
 from ops2deb.cli import app
 from ops2deb.lockfile import Lock
-from ops2deb.parser import ConfigurationFile
+from ops2deb.parser import Configuration
 
 yaml = ruamel.yaml.YAML(typ="safe")
 
@@ -354,7 +354,7 @@ def test_ops2deb_update_should_succeed_with_valid_configuration(
     configuration_path, lockfile_path, call_ops2deb
 ):
     result = call_ops2deb("update")
-    blueprints = ConfigurationFile(configuration_path).blueprints
+    blueprints = Configuration(configuration_path).blueprints
     lock = Lock(lockfile_path)
     sha256 = "f1be6dd36b503641d633765655e81cdae1ff8f7f73a2582b7468adceb5e212a9"
     assert "great-app can be bumped from 1.0.0 to 1.1.1" in result.stdout
@@ -375,7 +375,7 @@ def test_ops2deb_update_should_append_new_version_to_matrix_when_max_versions_is
         str(summary_path),
         configuration=mock_configuration_with_version_matrix,
     )
-    blueprints = ConfigurationFile(configuration_path).blueprints
+    blueprints = Configuration(configuration_path).blueprints
     lock = Lock(lockfile_path)
     sha256 = "f1be6dd36b503641d633765655e81cdae1ff8f7f73a2582b7468adceb5e212a9"
     assert "Added great-app v1.1.1" in summary_path.read_text()
@@ -396,7 +396,7 @@ def test_ops2deb_update_should_add_new_version_and_remove_old_versions_when_max_
         str(summary_path),
         configuration=mock_configuration_with_version_matrix,
     )
-    blueprints = ConfigurationFile(configuration_path).blueprints
+    blueprints = Configuration(configuration_path).blueprints
     assert result.exit_code == 0
     assert blueprints[0].matrix.versions == ["1.1.0", "1.1.1"]
     assert "Added great-app v1.1.1 and removed v1.0.0, v1.0.1" in summary_path.read_text()
@@ -416,7 +416,7 @@ def test_ops2deb_update_should_replace_version_with_versions_matrix_when_max_ver
         "--output-file",
         str(summary_path),
     )
-    blueprints = ConfigurationFile(configuration_path).blueprints
+    blueprints = Configuration(configuration_path).blueprints
     assert result.exit_code == 0
     assert blueprints[1].matrix.versions == ["1.0.0", "1.1.1"]
     assert "Added great-app v1.1.1" in summary_path.read_text()
@@ -454,7 +454,7 @@ def test_ops2deb_update_should_succeed_with_single_blueprint_configuration(
     result = call_ops2deb(
         "update", configuration=mock_configuration_single_blueprint_with_fetch
     )
-    blueprints = ConfigurationFile(configuration_path).blueprints
+    blueprints = Configuration(configuration_path).blueprints
     assert result.exit_code == 0
     assert blueprints[0].version == "1.1.1"
 
@@ -463,7 +463,7 @@ def test_ops2deb_update_should_reset_blueprint_revision_to_one(
     configuration_path, call_ops2deb
 ):
     call_ops2deb("update")
-    configuration = ConfigurationFile(configuration_path).aslist()
+    configuration = Configuration(configuration_path).aslist()
     assert "revision" not in configuration[0].keys()
     assert "revision" not in configuration[1].keys()
 
@@ -484,7 +484,7 @@ def test_ops2deb_update_should_fail_gracefully_when_server_error(
     """
 
     result = call_ops2deb("update", configuration=configuration_with_server_error)
-    blueprints = ConfigurationFile(configuration_path).blueprints
+    blueprints = Configuration(configuration_path).blueprints
     error = "Server error when requesting http://testserver/1.1.0/bad-app.zip"
     assert error in result.stdout
     assert blueprints[1].version == "1.1.1"
@@ -515,7 +515,7 @@ def test_ops2deb_update_should_only_update_blueprints_listed_with_only_option(
     configuration_path, call_ops2deb
 ):
     result = call_ops2deb("update", "--only", "great-app")
-    blueprints = ConfigurationFile(configuration_path).blueprints
+    blueprints = Configuration(configuration_path).blueprints
     assert result.exit_code == 0
     assert blueprints[1].version == "1.1.1"
     assert blueprints[2].version == "1.0.0"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from ops2deb.parser import Blueprint, ConfigurationFile
+from ops2deb.parser import Blueprint, Configuration
 
 
 @pytest.fixture
@@ -165,5 +165,5 @@ def test_parser__should_parse_lockfile_path_in_configuration_first_line(
     summary: this and that
     """
     configuration_path.write_text(configuration)
-    parser = ConfigurationFile(configuration_path)
+    parser = Configuration(configuration_path)
     assert parser.lockfile_path == Path("mylockfile.yml")


### PR DESCRIPTION
This new variable points to a directory in /tmp where you can store build artifacts and command outputs generated in the blueprint script.